### PR TITLE
Pokemarts expansion guide (gen 4)

### DIFF
--- a/src/gen4/universal/guides/pokemarts.md
+++ b/src/gen4/universal/guides/pokemarts.md
@@ -8,27 +8,27 @@ All offsets mentioned are based on the US version of the ROMs.
 ## Table of Contents
 * [Adding a new pokemart](#section)
   * [Editing Item prices](#subsection)
-* [Displaying the pokemart](#section-2)
+* [Displaying the new Pokemart](#section-2)
 
 ## Adding a new pokemart
 
 If you haven't already, you'll have to perform the ARM9 expansion since that's were the new pokemart(s) will be written to. 
-You can do so by clicking "Expand ARM9" in DSPRE toolbox, then go to Unpacked/SynthOverlay in your DSPRE project folder (which will be named ROMname_DSPRE_contents, and will be in the same folder of your ROM) and using your hex editor of choice open either the file 0009 if you're on Platinum or 0001 for HGSS.
+You can do so by clicking "Expand ARM9" in DSPRE toolbox, then go to Unpacked/SynthOverlay in your DSPRE project folder (which will be named ROMname_DSPRE_contents, and will be in the same folder of your ROM) and using your hex editor of choice open either file 0009 if you're on Platinum or 0001 for HGSS.
 
-You can write at whatever offset you want as long as it's empty, I will be writing my pokemart at 0x100. You need to sum `0x023C8000` to this offset, and write it down somehwere since you'll need it later to display the mart. In my case it will be `0x023C8100`.
+You can write at whatever offset you want as long as it's empty, I will be writing my pokemart at 0x100. You need to sum `0x023C8000` to this offset, and write it down since you'll need it later to display the mart in game. In my case it will be `0x023C8100`.
 
 Pokemarts are loaded in the RAM as a list of bytes of the items index numbers, with `FF FF` at the end of each mart, each item taking up two bytes.
 Refer to [Bulbapedia's list of items by index number](https://bulbapedia.bulbagarden.net/wiki/List_of_items_by_index_number_(Generation_IV)). 
-Keep in mind the bytes must be written in little endian! 
+Keep in mind the bytes must be written in little endian, so the order of bytes has to be swapped.
 
-In this tutorial I will be adding a pokemart that sells Rare Candies and Focus Sashes, their index numbers are respectively `0x32` and `0x0113`.
-So I will be writing `32 00 13 01 FF FF` at 0x100. Once you've added all your marts and wrote down their offsets you can save the file and close your hex editor.
-
+In this tutorial I will be adding a pokemart that sells Rare Candies and Focus Sashes, their index numbers are respectively `0x32` and `0x113`.
+So I will be writing `32 00 13 01 FF FF` at 0x100. Once you've added all your marts and wrote down their offsets you can save the file and close the hex editor.
 
 ### Editing item prices
-Item prices aren't stored in the pokemarts, instead they part of item data, meaning an item will always have the same price regardless of the pokemart.
-Item data is stored in the narc pl_item_data (Platinum) / a/0/1/7 (HGSS). The file you're looking will have the item index number as its name.
-The price is stored in the first two bytes in each file, so for example if I want to have Rare Candyies to be sold at 10'000 pokedollars (`0x2710`), I will have to edit 50.bin and change the first two bytes to `10 27`. Once you're done with hex editing remember to pack the narc before saving the ROM!
+Item prices aren't stored in the pokemarts, instead they are part of item data, meaning an item will always have the same price regardless of the pokemart it's being sold at.
+Item data is stored in the narc `pl_item_data` (Platinum) / `a/0/1/7` (HGSS). The file you're looking will have the item index number as its name.
+
+The price is stored in the first two bytes in each file, so for example if I want to have Rare Candyies to be sold at 10'000 pokedollars (`0x2710`), I will have to extract 50.bin and change the first two bytes to `10 27`. Once you've reinserted the file remember to pack the narc before saving the ROM!
 
 
 ## Displaying the new pokemart

--- a/src/gen4/universal/guides/pokemarts.md
+++ b/src/gen4/universal/guides/pokemarts.md
@@ -9,6 +9,7 @@ All offsets mentioned are based on the US version of the ROMs.
 * [Adding a new pokemart](#section)
   * [Editing Item prices](#subsection)
 * [Displaying the new Pokemart](#section-2)
+  * [Using Script Registers](#subsection-2)
 
 ## Adding a new pokemart
 
@@ -49,3 +50,14 @@ You can save the script and test the game now.
 This is what my full script 19 looks like, I assigned it to a NPC which will show the new Pokemart when talked to:
 
 ![Script](https://user-images.githubusercontent.com/57636185/224319492-a06935c8-1a2f-43fb-bdb8-5b537b371c84.PNG)
+
+### Using Script Registers
+To avoid using the AdrsValueSet three times in a row, it's possible to do the same process using the script register commands RegDataSet and AdrsRegSet, so that my earlier script will instead look like this:
+```
+RegDataSet 0 0x023C8100
+AdrsRegSet 0x0210FA3C 0
+SpMartScreen 0
+RegDataSet 0 0x020FBA54
+AdrsRegSet 0x0210FA3C 0
+```
+The only caveat is that the script is normally "broken" and only writes one byte into memory, so to fix it you have to hex edit the arm9 at `0x3F7CA` (Platinum) / `0x40996` (HGSS) and change `01 70` to `01 60`. Thanks to AdAstra for having looked into this issue.

--- a/src/gen4/universal/guides/pokemarts.md
+++ b/src/gen4/universal/guides/pokemarts.md
@@ -44,8 +44,8 @@ AdrsValueSet 0x0210FA3C 0x54
 AdrsValueSet 0x0210FA3D 0xBA
 AdrsValueSet 0x0210FA3E 0x0F
 ```
-The first three commands change the original pointer to the new one in the synthetic overlay, then the Mart is opened like normal with `SpMartScreen 0`, and with the last three commands the original pointer is restored. Only 3 bytes are changed instead of 4 since RAM offsets always starts with 02. Again the pointers are written in little endian, so `0x023C8100` will look like `00 81 3C 02` in the RAM.
+The first three commands change the original pointer to the new one in the synthetic overlay, then the Mart is opened like normal with `SpMartScreen 0`, and with the last three commands the original pointer is restored. Only 3 bytes are changed instead of 4 since RAM offsets always start with 02. Again the pointers are written in little endian, so `0x023C8100` will look like `00 81 3C 02` in the RAM.
 You can save the script and test the game now.
-This is what my full script 19 looks like, I assigned it to a NPC:
+This is what my full script 19 looks like, I assigned it to a NPC which will show the new Pokemart when talked to:
 
 ![Script](https://user-images.githubusercontent.com/57636185/224319492-a06935c8-1a2f-43fb-bdb8-5b537b371c84.PNG)

--- a/src/gen4/universal/guides/pokemarts.md
+++ b/src/gen4/universal/guides/pokemarts.md
@@ -1,8 +1,8 @@
-# How to add new pokemarts in gen 4 games
+# Adding New Pokemarts (Pt/HGSS)
 > This guide was written by SpagoAsparago.
 
-This is a guide on how to add and display new pokemarts in Platinum and HGSS
-All offsets are based on the US version of the ROMs.
+This is a guide on how to add and display new pokemarts in Platinum and HGSS.
+All offsets mentioned are based on the US version of the ROMs. 
 
 --- 
 ## Table of Contents
@@ -13,32 +13,39 @@ All offsets are based on the US version of the ROMs.
 ## Adding a new pokemart
 
 If you haven't already, you'll have to perform the ARM9 expansion since that's were the new pokemart(s) will be written to. 
-You can do so by using DSPRE's toolbox. Save your ROM, then use Tinke to extract the synthetic overlay (weather_sys_9.bin in weather_sys.narc for Platinum, and 8_0.bin in a/0/2/8 for HGSS) and open it with your hex editor of choice.
-Pokemarts are loaded in the RAM as a list of bytes of the items index numbers, with `FF FF` at the end of each mart, each item taking two bytes.
+You can do so by clicking "Expand ARM9" in DSPRE toolbox, then go to Unpacked/SynthOverlay in your DSPRE project folder (which will be named ROMname_DSPRE_contents, and will be in the same folder of your ROM) and using your hex editor of choice open either the file 0009 if you're on Platinum or 0001 for HGSS.
+
+You can write at whatever offset you want as long as it's empty, I will be writing my pokemart at 0x100. You need to sum `0x023C8000` to this offset, and write it down somehwere since you'll need it later to display the mart. In my case it will be `0x023C8100`.
+
+Pokemarts are loaded in the RAM as a list of bytes of the items index numbers, with `FF FF` at the end of each mart, each item taking up two bytes.
 Refer to [Bulbapedia's list of items by index number](https://bulbapedia.bulbagarden.net/wiki/List_of_items_by_index_number_(Generation_IV)). 
-Note that the bytes must be written in little endian, so if you are adding a pokemart that sells rare candies and masterballs (respecitve index numbers are `0x0032` and `0x0001`) you would write 
-`32 00 01 00 FF FF`
-At the offset in the synthetic overlay were your pokemart was added, add either if you're using Platinum or if you're using HGSS, and write it down.
+Keep in mind the bytes must be written in little endian! 
+
+In this tutorial I will be adding a pokemart that sells Rare Candies and Focus Sashes, their index numbers are respectively `0x32` and `0x0113`.
+So I will be writing `32 00 13 01 FF FF` at 0x100. Once you've added all your marts and wrote down their offsets you can save the file and close your hex editor.
+
 
 ### Editing item prices
-Item prices aren't stored in the pokemarts, instead they are just half the value of the item, and those values are stored in the item narc (pl_item_data for Platinum
-You can either hex edit those or use PokEditor (? to be confirmed) to edit them, but keep in mind that an item will have the same price in every pokemart.
+Item prices aren't stored in the pokemarts, instead they part of item data, meaning an item will always have the same price regardless of the pokemart.
+Item data is stored in the narc pl_item_data (Platinum) / a/0/1/7 (HGSS). The file you're looking will have the item index number as its name.
+The price is stored in the first two bytes in each file, so for example if I want to have Rare Candyies to be sold at 10'000 pokedollars (`0x2710`), I will have to edit 50.bin and change the first two bytes to `10 27`. Once you're done with hex editing remember to pack the narc before saving the ROM!
 
 
 ## Displaying the new pokemart
-The easiest way new pokemarts can be displayed (without overwriting existing ones) is by changing the pointer of an existing pokemart and using the scripting command to normally access the pokemart, and once you're done changing the pointer back.
-I'll use the offset of pokemart 0 for convenience but it can be applied to any other one. 
-The way it's done is by using the AdrsSetValue command 
-For example, in Platinum the pointer of spMart 0 is at 0x, while my new pokemart was written at 0x in the synthetic overlay which will result in it being loaded at 0x in the RAM
-Using a script like this:
+The easiest way new pokemarts can be displayed (without overwriting existing ones) is by using a script to change the pointer of an existing pokemart trough the `AdrsValueSet` command, normally accessing the pokemart, and once you're done changing the pointer back.
+I'll use the offset of `SpMartScreen 0`, the pointer normally being `0x020EB978` (Platinum) / `020FBA54` (HGSS) and is found at `0x02100B1C` (Platinum) / `0x0210FA3C` (HGSS) in the RAM.
+Since I'm using HGSS, the relevant part of my script will look like this:
 ```
-AdrsSetValue 0x 
-AdrsSetValue 0x
-AdrsSetValue 0x
+AdrsValueSet 0x0210FA3C 0x00
+AdrsValueSet 0x0210FA3D 0x81
+AdrsValueSet 0x0210FA3E 0x3C
 SpMartScreen 0
-AdrsSetValue 0x
-AdrsSetValue 0x
-AdrsSetValue 0x
+AdrsValueSet 0x0210FA3C 0x54
+AdrsValueSet 0x0210FA3D 0xBA
+AdrsValueSet 0x0210FA3E 0x0F
 ```
-Will first change the pointer to our new pokemart, now the game will open the mart at the pointer we changed to, and then change it back to the original one so it's still accessible.
-(The pointers always starts with 02 so it's only necessary to edit 3 bytes)
+The first three commands change the original pointer to the new one in the synthetic overlay, then the Mart is opened like normal with `SpMartScreen 0`, and with the last three commands the original pointer is restored. Only 3 bytes are changed instead of 4 since RAM offsets always starts with 02. Again the pointers are written in little endian, so `0x023C8100` will look like `00 81 3C 02` in the RAM.
+You can save the script and test the game now.
+This is what my full script 19 looks like, I assigned it to a NPC:
+
+![Script](https://user-images.githubusercontent.com/57636185/224319492-a06935c8-1a2f-43fb-bdb8-5b537b371c84.PNG)

--- a/src/gen4/universal/guides/pokemarts.md
+++ b/src/gen4/universal/guides/pokemarts.md
@@ -1,0 +1,44 @@
+# How to add new pokemarts in gen 4 games
+> This guide was written by SpagoAsparago.
+
+This is a guide on how to add and display new pokemarts in Platinum and HGSS
+All offsets are based on the US version of the ROMs.
+
+--- 
+## Table of Contents
+* [Adding a new pokemart](#section)
+  * [Editing Item prices](#subsection)
+* [Displaying the pokemart](#section-2)
+
+## Adding a new pokemart
+
+If you haven't already, you'll have to perform the ARM9 expansion since that's were the new pokemart(s) will be written to. 
+You can do so by using DSPRE's toolbox. Save your ROM, then use Tinke to extract the synthetic overlay (weather_sys_9.bin in weather_sys.narc for Platinum, and 8_0.bin in a/0/2/8 for HGSS) and open it with your hex editor of choice.
+Pokemarts are loaded in the RAM as a list of bytes of the items index numbers, with `FF FF` at the end of each mart, each item taking two bytes.
+Refer to [Bulbapedia's list of items by index number](https://bulbapedia.bulbagarden.net/wiki/List_of_items_by_index_number_(Generation_IV)). 
+Note that the bytes must be written in little endian, so if you are adding a pokemart that sells rare candies and masterballs (respecitve index numbers are `0x0032` and `0x0001`) you would write 
+`32 00 01 00 FF FF`
+At the offset in the synthetic overlay were your pokemart was added, add either if you're using Platinum or if you're using HGSS, and write it down.
+
+### Editing item prices
+Item prices aren't stored in the pokemarts, instead they are just half the value of the item, and those values are stored in the item narc (pl_item_data for Platinum
+You can either hex edit those or use PokEditor (? to be confirmed) to edit them, but keep in mind that an item will have the same price in every pokemart.
+
+
+## Displaying the new pokemart
+The easiest way new pokemarts can be displayed (without overwriting existing ones) is by changing the pointer of an existing pokemart and using the scripting command to normally access the pokemart, and once you're done changing the pointer back.
+I'll use the offset of pokemart 0 for convenience but it can be applied to any other one. 
+The way it's done is by using the AdrsSetValue command 
+For example, in Platinum the pointer of spMart 0 is at 0x, while my new pokemart was written at 0x in the synthetic overlay which will result in it being loaded at 0x in the RAM
+Using a script like this:
+```
+AdrsSetValue 0x 
+AdrsSetValue 0x
+AdrsSetValue 0x
+SpMartScreen 0
+AdrsSetValue 0x
+AdrsSetValue 0x
+AdrsSetValue 0x
+```
+Will first change the pointer to our new pokemart, now the game will open the mart at the pointer we changed to, and then change it back to the original one so it's still accessible.
+(The pointers always starts with 02 so it's only necessary to edit 3 bytes)


### PR DESCRIPTION
# Name of Resource
Adding New Pokemarts (Pt/HGSS)
# Description
A guide on how to add new Pokemarts to Platinum/HGSS
# Which Generation (4/5/Universal)?
4
# Notes
Offsets used are based on US version of the ROMs